### PR TITLE
Aviso para desconsiderar o path completo

### DIFF
--- a/geravhost.sh
+++ b/geravhost.sh
@@ -16,7 +16,7 @@
 echo "Informe o nome do servidor (Ex.: siteexemplo) :"
 read vhost
  
-echo "Informe o caminho do site (Ex.: /var/www/sitexemplo) :"
+echo "Informe o caminho do site, desconsiderando a raiz "/var/www" (Ex.: sitexemplo) :"
 read path
  
 echo "Criando configuração de VHost para o servidor"


### PR DESCRIPTION
Não é preciso informar o path completo uma vez que a raiz /var/www já está inserida no código.
